### PR TITLE
Use Imagemagick 6.8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN mkdir -p /tmp/imagemagick && \
     cd ImageMagick-${IMAGEMAGICK_VERSION} && \
     ./configure \
       --prefix=/usr \
+      --sysconfdir=/etc \
+      --libdir=/usr/lib/x86_64-linux-gnu \
       --enable-shared \
       --with-modules \
       --disable-openmp \


### PR DESCRIPTION
## WHY

ImageMagick ealier than v6.8.5 has some bugs about WebP (and memory leak).
## REF
- [ImageMagick Changelog](http://www.imagemagick.org/script/changelog.php)
