### PR TITLE
Specify locust command with docker run

### DIFF
--- a/script/run_locust
+++ b/script/run_locust
@@ -20,4 +20,5 @@ docker run \
   -p 8089:8089 \
   -v ${BASE_DIRECTORY}/test/performance:/test \
   locust \
+  locust \
   ${LOCUST_ARGS}


### PR DESCRIPTION
## WHY

`docker run` must specify command itself if you'd like to specify command argument.

```
$ docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
```

``` shell
# docker run --rm -it --name locust -p 8089:8089 -v ${BASE_DIRECTORY}/test/performance:/test locust ${LOCUST_ARGS}
$ script/run_locust -f locustfile.py
exec: "-f": executable file not found in $PATHFATA[0000] Error response from daemon: Cannot start container 2a4e2fbde4a34f7edf548f616b65ab867af98f1b37ab93b176ae04c0b7028149: exec: "-f": executable file not found in $PATH
```
## WHAT

Explicitly specify `locust` command.

``` shell
# docker run --rm -it --name locust -p 8089:8089 -v ${BASE_DIRECTORY}/test/performance:/test locust locust ${LOCUST_ARGS}
$ script/run_locust -f locustfile.py
[2014-12-25 10:07:09,485] deb101a08a26/INFO/locust.main: Starting web monitor at *:8089
[2014-12-25 10:07:09,487] deb101a08a26/INFO/locust.main: Starting Locust 0.7.2
^C[2014-12-25 10:07:10,360] deb101a08a26/ERROR/stderr: KeyboardInterrupt
[2014-12-25 10:07:10,360] deb101a08a26/INFO/locust.main: Shutting down (exit code 0), bye.
 Name                                                          # reqs      # fails     Avg     Min     Max  |  Median   req/s
--------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------------------------
 Total                                                              0     0(0.00%)                                       0.00
```
## REF

https://docs.docker.com/reference/run/
