### PR TITLE
Apply monkey patch to ImageMagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN apt-get update && \
       libperl-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Build ImageMagick with WebP support
+# Add monkey patch for ImageMagick to suppress semaphore error
 COPY files/wand.patch /tmp/wand.patch
 
+# Build ImageMagick with WebP support and monkey patch
 RUN mkdir -p /tmp/imagemagick && \
     cd /tmp/imagemagick && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Build ImageMagick with WebP support
+COPY files/wand.patch /tmp/wand.patch
+
 RUN mkdir -p /tmp/imagemagick && \
     cd /tmp/imagemagick && \
     apt-get update && \
@@ -28,6 +30,7 @@ RUN mkdir -p /tmp/imagemagick && \
       ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz && \
     tar zxf ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz && \
     cd ImageMagick-${IMAGEMAGICK_VERSION} && \
+    patch -p0 < /tmp/wand.patch && \
     ./configure \
       --prefix=/usr \
       --sysconfdir=/etc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
       libperl-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Add monkey patch for ImageMagick to suppress semaphore error
+# Add monkey patch for ImageMagick (wand/wand.c) to suppress semaphore error
 COPY files/wand.patch /tmp/wand.patch
 
 # Build ImageMagick with WebP support and monkey patch

--- a/files/wand.patch
+++ b/files/wand.patch
@@ -2,13 +2,13 @@ diff --git wand/wand.c wand/wand.c
 index 9da7d87..61ac7ed 100644
 --- wand/wand.c
 +++ wand/wand.c
-@@ -78,7 +78,10 @@ WandExport size_t AcquireWandId(void)
- 
+@@ -78,0 +78,0 @@ WandExport size_t AcquireWandId(void)
+
    if (wand_semaphore == (SemaphoreInfo *) NULL)
      AcquireSemaphoreInfo(&wand_semaphore);
 -  LockSemaphoreInfo(wand_semaphore);
 +
-+  if (wand_semaphore == (SemaphoreInfo *) NULL)
++  if (wand_semaphore != (SemaphoreInfo *) NULL)
 +    (void) LockSemaphoreInfo(wand_semaphore);
 +
    if ((wand_ids == (SplayTreeInfo *) NULL) && (instantiate_wand == MagickFalse))
@@ -20,7 +20,7 @@ index 9da7d87..61ac7ed 100644
    (void) AddValueToSplayTree(wand_ids,(const void *) id,(const void *) id);
 -  UnlockSemaphoreInfo(wand_semaphore);
 +
-+  if (wand_semaphore == (SemaphoreInfo *) NULL)
++  if (wand_semaphore != (SemaphoreInfo *) NULL)
 +    UnlockSemaphoreInfo(wand_semaphore);
 +
    return(id);
@@ -32,7 +32,7 @@ index 9da7d87..61ac7ed 100644
      AcquireSemaphoreInfo(&wand_semaphore);
 -  LockSemaphoreInfo(wand_semaphore);
 +
-+  if (wand_semaphore == (SemaphoreInfo *) NULL)
++  if (wand_semaphore != (SemaphoreInfo *) NULL)
 +    LockSemaphoreInfo(wand_semaphore);
 +
    if (wand_ids != (SplayTreeInfo *) NULL)
@@ -41,7 +41,7 @@ index 9da7d87..61ac7ed 100644
 -  UnlockSemaphoreInfo(wand_semaphore);
 -  DestroySemaphoreInfo(&wand_semaphore);
 +
-+  if (wand_semaphore == (SemaphoreInfo *) NULL) {
++  if (wand_semaphore != (SemaphoreInfo *) NULL) {
 +    UnlockSemaphoreInfo(wand_semaphore);
 +    DestroySemaphoreInfo(&wand_semaphore);
 +  }
@@ -53,13 +53,13 @@ index 9da7d87..61ac7ed 100644
  WandExport void RelinquishWandId(const size_t id)
  {
 -  LockSemaphoreInfo(wand_semaphore);
-+  if (wand_semaphore == (SemaphoreInfo *) NULL)
++  if (wand_semaphore != (SemaphoreInfo *) NULL)
 +    LockSemaphoreInfo(wand_semaphore);
 +
    if (wand_ids != (SplayTreeInfo *) NULL)
      (void) DeleteNodeByValueFromSplayTree(wand_ids,(const void *) id);
 -  UnlockSemaphoreInfo(wand_semaphore);
 +
-+  if (wand_semaphore == (SemaphoreInfo *) NULL)
++  if (wand_semaphore != (SemaphoreInfo *) NULL)
 +    UnlockSemaphoreInfo(wand_semaphore);
  }

--- a/files/wand.patch
+++ b/files/wand.patch
@@ -1,0 +1,65 @@
+diff --git wand/wand.c wand/wand.c
+index 9da7d87..61ac7ed 100644
+--- wand/wand.c
++++ wand/wand.c
+@@ -78,7 +78,10 @@ WandExport size_t AcquireWandId(void)
+ 
+   if (wand_semaphore == (SemaphoreInfo *) NULL)
+     AcquireSemaphoreInfo(&wand_semaphore);
+-  LockSemaphoreInfo(wand_semaphore);
++
++  if (wand_semaphore == (SemaphoreInfo *) NULL)
++    (void) LockSemaphoreInfo(wand_semaphore);
++
+   if ((wand_ids == (SplayTreeInfo *) NULL) && (instantiate_wand == MagickFalse))
+     {
+       wand_ids=NewSplayTree((int (*)(const void *,const void *)) NULL,
+@@ -87,7 +90,10 @@ WandExport size_t AcquireWandId(void)
+     }
+   id++;
+   (void) AddValueToSplayTree(wand_ids,(const void *) id,(const void *) id);
+-  UnlockSemaphoreInfo(wand_semaphore);
++
++  if (wand_semaphore == (SemaphoreInfo *) NULL)
++    UnlockSemaphoreInfo(wand_semaphore);
++
+   return(id);
+ }
+ 
+@@ -115,12 +121,18 @@ WandExport void DestroyWandIds(void)
+ {
+   if (wand_semaphore == (SemaphoreInfo *) NULL)
+     AcquireSemaphoreInfo(&wand_semaphore);
+-  LockSemaphoreInfo(wand_semaphore);
++
++  if (wand_semaphore == (SemaphoreInfo *) NULL)
++    LockSemaphoreInfo(wand_semaphore);
++
+   if (wand_ids != (SplayTreeInfo *) NULL)
+     wand_ids=DestroySplayTree(wand_ids);
+   instantiate_wand=MagickFalse;
+-  UnlockSemaphoreInfo(wand_semaphore);
+-  DestroySemaphoreInfo(&wand_semaphore);
++
++  if (wand_semaphore == (SemaphoreInfo *) NULL) {
++    UnlockSemaphoreInfo(wand_semaphore);
++    DestroySemaphoreInfo(&wand_semaphore);
++  }
+ }
+ 
+ /*
+@@ -147,8 +159,12 @@ WandExport void DestroyWandIds(void)
+ */
+ WandExport void RelinquishWandId(const size_t id)
+ {
+-  LockSemaphoreInfo(wand_semaphore);
++  if (wand_semaphore == (SemaphoreInfo *) NULL)
++    LockSemaphoreInfo(wand_semaphore);
++
+   if (wand_ids != (SplayTreeInfo *) NULL)
+     (void) DeleteNodeByValueFromSplayTree(wand_ids,(const void *) id);
+-  UnlockSemaphoreInfo(wand_semaphore);
++
++  if (wand_semaphore == (SemaphoreInfo *) NULL)
++    UnlockSemaphoreInfo(wand_semaphore);
+ }

--- a/files/wand.patch
+++ b/files/wand.patch
@@ -1,9 +1,9 @@
 diff --git wand/wand.c wand/wand.c
-index 9da7d87..61ac7ed 100644
+index 9da7d87..67cf2f7 100644
 --- wand/wand.c
 +++ wand/wand.c
-@@ -78,0 +78,0 @@ WandExport size_t AcquireWandId(void)
-
+@@ -78,7 +78,10 @@ WandExport size_t AcquireWandId(void)
+ 
    if (wand_semaphore == (SemaphoreInfo *) NULL)
      AcquireSemaphoreInfo(&wand_semaphore);
 -  LockSemaphoreInfo(wand_semaphore);


### PR DESCRIPTION
## WHY

When you make _many_ requests to this server, it sometimes fails with this error, 

```
Dec 25 18:37:02 core-01 docker[11960]: ocess: magick/semaphore.c:339: LockSemaphoreInfo: Assertion `semaphore_info != (SemaphoreInfo *) ((void *)0)' failed.
```

and dumps core (on CoreOS).

```
Jan 06 14:19:42 xxx.ap-northeast-1.compute.internal systemd-coredump[8970]: Process 70 (nginx) of user 0 dumped core.
```

The relavant part of ImageMagick is below (magick/semaphore.c).

```c
MagickExport void LockSemaphoreInfo(SemaphoreInfo *semaphore_info)
{
  assert(semaphore_info != (SemaphoreInfo *) NULL);
```

This method is called from wand/wand.c .

```c
WandExport size_t AcquireWandId(void)
{
  static size_t
    id = 0;

  if (wand_semaphore == (SemaphoreInfo *) NULL)
    AcquireSemaphoreInfo(&wand_semaphore);
  LockSemaphoreInfo(wand_semaphore);

/* ...and more */
```

## WHAT

Apply monkey patch (files/wand.patch) to ImageMagick.
This monkey patch adds some conditions checking `wand_semaphore` variable.

Now you can pull & test Docker image of this branch from [quay.io/dtan4/nginx-image-server:latest](https://quay.io/repository/dtan4/nginx-image-server).

## REF

- [ImageMagickとマルチスレッドは混ぜるなキケン!? - shimada-kの日記](http://shimada-k.hateblo.jp/entry/20110804/1312386221)
- [magick/semaphore.c:288: LockSemaphoreInfo: Assertion `semaph - ImageMagick](http://www.imagemagick.org/discourse-server/viewtopic.php?t=14975)