### PR TITLE
Use ngx_small_light v0.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/wantedly/buildpack-deps:14.04
 MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
 
 ENV NGINX_VERSION 1.6.2
-ENV NGX_SMALL_LIGHT_VERSION 0.6.3
+ENV NGX_SMALL_LIGHT_VERSION 0.6.4
 ENV IMAGEMAGICK_VERSION 6.8.5-5
 
 # Install dependency packages

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see https://github.com/cubicdaiya/ngx_small_light for more information ab
 
 * `latest`
  * Nginx 1.6.2
- * ngx_small_light 0.6.3
+ * ngx_small_light 0.6.4
  * ImageMagick 6.8.5 (Q16) with WebP support
 
 ## HOW TO USE


### PR DESCRIPTION
## WHY
To fix semaphore error
See https://github.com/cubicdaiya/ngx_small_light/pull/20 for more about v0.6.4 and the error.