### PR TITLE
Validate resize parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN cd /tmp/nginx-${NGINX_VERSION} && \
     rm -rf /tmp/*
 
 RUN mkdir -p /etc/nginx && \
+    mkdir -p /opt/nginx/perl/lib && \
     mkdir -p /var/run && \
     mkdir -p /etc/nginx/conf.d && \
     mkdir -p /var/www/nginx/cache && \
@@ -77,8 +78,9 @@ RUN mkdir -p /etc/nginx && \
     mkdir -p /var/www/nginx/tmp
 
 # Add config files
-COPY files/nginx.conf /etc/nginx/nginx.conf
-COPY files/mime.types /etc/nginx/mime.types
+COPY files/nginx.conf   /etc/nginx/nginx.conf
+COPY files/mime.types   /etc/nginx/mime.types
+COPY files/validator.pm /opt/nginx/perl/lib/validator.pm
 
 EXPOSE 80 8090
 

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -85,8 +85,8 @@ http {
 
       # Image processing for images in local file
       location ~ ^/local/small_light[^/]*/(.+)$ {
-        set $file $1;
-        rewrite ^ /$file;
+        set $small_light_maximum_size 3072;
+        perl validator::handler;
       }
 
       # Image processing for images in AWS S3

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -91,6 +91,7 @@ http {
 
       # Image processing for images in AWS S3
       location ~ ^/small_light[^/]*/(.+)$ {
+        set $small_light_maximum_size 3072;
         perl validator::handler;
       }
 

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -15,6 +15,9 @@ events {
 }
 
 http {
+    perl_modules perl/lib;
+    perl_require validator.pm;
+
     perl_set $server_name_from_env 'sub { return $ENV{"SERVER_NAME"}; }';
     perl_set $s3_host_from_env 'sub { return $ENV{"S3_HOST"}; }';
 
@@ -88,8 +91,7 @@ http {
 
       # Image processing for images in AWS S3
       location ~ ^/small_light[^/]*/(.+)$ {
-        set $file $1;
-        rewrite ^ /$file;
+        perl validator::handler;
       }
 
       location ~ ^/images/(.+)$ {

--- a/files/validator.pm
+++ b/files/validator.pm
@@ -32,6 +32,9 @@ sub handler {
   }
 
   if ($bad_request) {
+    # to avoid ngx_small_light process and return 400
+    $r->send_http_header;
+
     return HTTP_BAD_REQUEST;
   }
 

--- a/files/validator.pm
+++ b/files/validator.pm
@@ -6,7 +6,7 @@ use warnings;
 
 sub handler {
   my $r = shift;
-  my $uri = "/" . ($r->uri =~ /^\/small_light[^\/]*\/(.+)$/m)[0];
+  my $uri = "/" . ($r->uri =~ /^.*\/small_light[^\/]*\/(.+)$/m)[0];
   my $threshold = $r->variable("small_light_maximum_size");
 
   unless ($threshold) {

--- a/files/validator.pm
+++ b/files/validator.pm
@@ -9,10 +9,8 @@ sub handler {
   my $uri = "/" . ($r->uri =~ /^\/small_light[^\/]*\/(.+)$/m)[0];
   my $threshold = $r->variable("small_light_maximum_size");
 
-  $r->log_error(100, $uri);
-
   unless ($threshold) {
-    $r->log_error(100, "no threshold!");
+    $r->log_error(100, "small_light_maximum_size is not defined!");
     $r->internal_redirect($uri);
 
     return OK;
@@ -26,7 +24,7 @@ sub handler {
 
     if (grep(/^${key}$/, ("cw", "dw", "ch", "dh"))) {
       if ($value > $threshold) {
-        $r->log_error(100, "oversize!");
+        $r->log_error(100, "Invalid resize parameter, " . $key . ": " . $value);
         $bad_request = 1;
         last;
       }
@@ -34,7 +32,6 @@ sub handler {
   }
 
   if ($bad_request) {
-    $r->log_error(100, "bad request!");
     return HTTP_BAD_REQUEST;
   }
 

--- a/files/validator.pm
+++ b/files/validator.pm
@@ -1,0 +1,47 @@
+package validator;
+
+use nginx;
+use strict;
+use warnings;
+
+sub handler {
+  my $r = shift;
+  my $uri = "/" . ($r->uri =~ /^\/small_light[^\/]*\/(.+)$/m)[0];
+  my $threshold = 500;
+
+  $r->log_error(100, $uri);
+
+  unless ($threshold) {
+    $r->log_error(100, "no threshold!");
+    $r->internal_redirect($uri);
+
+    return OK;
+  }
+
+  my $bad_request = 0;
+  my @params = $r->uri =~ /([a-zA-Z]+=[0-9a-zA-Z]+),?/g;
+
+  foreach my $param (@params) {
+    my ($key, $value) = split("=", $param);
+
+    if (grep(/^${key}$/, ("cw", "dw", "ch", "dh"))) {
+      if ($value > $threshold) {
+        $r->log_error(100, "oversize!");
+        $bad_request = 1;
+        last;
+      }
+    }
+  }
+
+  if ($bad_request) {
+    $r->log_error(100, "bad request!");
+    return HTTP_BAD_REQUEST;
+  }
+
+  $r->internal_redirect($uri);
+
+  return OK;
+}
+
+1;
+__END__

--- a/files/validator.pm
+++ b/files/validator.pm
@@ -7,7 +7,7 @@ use warnings;
 sub handler {
   my $r = shift;
   my $uri = "/" . ($r->uri =~ /^\/small_light[^\/]*\/(.+)$/m)[0];
-  my $threshold = 500;
+  my $threshold = $r->variable("small_light_maximum_size");
 
   $r->log_error(100, $uri);
 

--- a/test/feature/spec/nginx_image_server_spec.rb
+++ b/test/feature/spec/nginx_image_server_spec.rb
@@ -36,5 +36,28 @@ describe server(:target) do
       expect(response.body).to include("Active connections")
     end
   end
-end
 
+  describe http('http://target/local/small_light(dh=3600,da=l,ds=s,of=webp)/images/example.jpg') do
+    it "responds Bad Request 400" do
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe http('http://target/local/small_light(ch=3600,da=l,ds=s,of=webp)/images/example.jpg') do
+    it "responds Bad Request 400" do
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe http('http://target/local/small_light(dw=3600,da=l,ds=s,of=webp)/images/example.jpg') do
+    it "responds Bad Request 400" do
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe http('http://target/local/small_light(cw=3600,da=l,ds=s,of=webp)/images/example.jpg') do
+    it "responds Bad Request 400" do
+      expect(response.status).to eq(400)
+    end
+  end
+end


### PR DESCRIPTION
## WHY
When we made request resizing image to VERY LARGE size to current nginx-image-server, it falls into busy and down. 

## WHAT
Validate resize parameters (`cw`, `dw`, `ch`, `dh`) at every request by Perl module.
It restricts them to __3072__ or under.

If oversize request is given, server will return `400 Bad Request`.