### PR TITLE
Use ImageMagick 6.8.6-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
 
 ENV NGINX_VERSION 1.6.2
 ENV NGX_SMALL_LIGHT_VERSION 0.6.4
-ENV IMAGEMAGICK_VERSION 6.8.5-5
+ENV IMAGEMAGICK_VERSION 6.8.6-8
 
 # Install dependency packages
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please see https://github.com/cubicdaiya/ngx_small_light for more information ab
 * `latest`
  * Nginx 1.6.2
  * ngx_small_light 0.6.4
- * ImageMagick 6.8.5 (Q16) with WebP support
+ * ImageMagick 6.8.6-8 (Q16) with WebP support
 
 ## HOW TO USE
 


### PR DESCRIPTION
## WHY
To fix the issue ImageMagick 6.8.5-5 converts CMYK jpeg to negate image.

## WHAT
### Changed

* Use ImageMagick 6.8.6-8

### Bugs Fixed

* ImageMagick 6.8.5-5 converts CMYK jpeg to negate image

## REF

> 2013-07-31 6.8.6-8 Cristy <quetzlzacatenango@image...>
Properly handle interlaced GIF images with less than 8 rows (reference http://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=23812).
**Ensure image colorspace is sRGB when writing WebP format** (reference http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=23841).
Avoid deadlock with logging subsystem (reference http://www.imagemagick.org/discourse-server/viewtopic.php?f=2&t=23849).

http://www.imagemagick.org/script/changelog.php