### PR TITLE
Don't use target as image name

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -9,7 +9,7 @@ build:
         name: Build quay.io/wantedly/nginx-image-server
         code: |
           cd ${WERCKER_SOURCE_DIR}
-          docker build -t target .
+          docker build -t quay.io/wantedly/nginx-image-server .
     - script:
         name: Run quay.io/wantedly/nginx-image-server
         code: >


### PR DESCRIPTION
## WHY
To use `quay.io/wantedly/nginx-image-server` as image name through the wercker build.
We're testing the image pulled from quay.io instead of builded image on wercker, this is mistake by me :(