### PR TITLE
Use ngx_small_light v0.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/wantedly/buildpack-deps:14.04
 MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
 
 ENV NGINX_VERSION 1.6.2
-ENV NGX_SMALL_LIGHT_VERSION 0.6.5
+ENV NGX_SMALL_LIGHT_VERSION 0.6.6
 ENV IMAGEMAGICK_VERSION 6.8.6-8
 
 # Install dependency packages

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see https://github.com/cubicdaiya/ngx_small_light for more information ab
 
 * `latest`
  * Nginx 1.6.2
- * ngx_small_light 0.6.5
+ * ngx_small_light 0.6.6
  * ImageMagick 6.8.6-8 (Q16) with WebP support
 
 ## HOW TO USE


### PR DESCRIPTION
## WHY

[ngx_small_light v0.6.6](https://github.com/cubicdaiya/ngx_small_light/releases/tag/v0.6.6) was released!
It includes some fix and feature:

- Fix color-inversion bug of CMYK image
- Add option `cmyk2rgb` to convert CMYK image to RGB