### PR TITLE
Use quay.io/wantedly/locust image

### DIFF
--- a/script/run-locust
+++ b/script/run-locust
@@ -19,6 +19,5 @@ docker run \
   --name locust \
   -p 8089:8089 \
   -v ${BASE_DIRECTORY}/test/performance:/test \
-  locust \
-  locust \
+  quay.io/wantedly/locust:latest \
   ${LOCUST_ARGS}

--- a/test/performance/Dockerfile
+++ b/test/performance/Dockerfile
@@ -1,7 +1,0 @@
-FROM python:2.7.8
-MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
-
-RUN pip install locustio pyzmq
-RUN mkdir /test
-WORKDIR /test
-CMD ["locust"]


### PR DESCRIPTION
## WHY
We created [quay.io/wantedly/locust](https://quay.io/repository/wantedly/locust) image, instead of Dockerfile contained in this repository.