### PR TITLE
Use ngx_small_light v0.6.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/wantedly/buildpack-deps:14.04
 MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
 
 ENV NGINX_VERSION 1.6.2
-ENV NGX_SMALL_LIGHT_VERSION 0.6.6
+ENV NGX_SMALL_LIGHT_VERSION 0.6.8
 ENV IMAGEMAGICK_VERSION 6.8.6-8
 
 # Install dependency packages

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see https://github.com/cubicdaiya/ngx_small_light for more information ab
 
 * `latest`
  * Nginx 1.6.2
- * ngx_small_light 0.6.6
+ * ngx_small_light 0.6.8
  * ImageMagick 6.8.6-8 (Q16) with WebP support
 
 ## HOW TO USE


### PR DESCRIPTION
This release includes some serious fixes for memory leaks.

Especially https://github.com/cubicdaiya/ngx_small_light/commit/1db0a98d127f8505cdc15d7e7101c8b14ff16a18 fixes the memory leak in all cases when ImageMagick is used.

## P.S. 

As this docker file is useful, I sometimes use it for test. Thanks.
