### PR TITLE
Use beta channel as default

### DIFF
--- a/coreos/config.rb
+++ b/coreos/config.rb
@@ -34,7 +34,7 @@ File.write(File.join(File.dirname(__FILE__), "user-data"), erb.result(binding))
 $num_instances=1
 
 # Official CoreOS channel from which updates should be downloaded
-$update_channel="alpha"
+$update_channel="beta"
 
 # Log the serial consoles of CoreOS VMs to log/
 # Enable by setting value to true, disable with false

--- a/coreos/user-data.yml.erb
+++ b/coreos/user-data.yml.erb
@@ -2,7 +2,7 @@
 
 coreos:
   update:
-    group: alpha
+    group: beta
     reboot-strategy: off
   units:
     - name: settimezone.service


### PR DESCRIPTION
## WHY & WHAT

Beta channel is the _most stable_ channel, better than alpha. We should use it as default.