### PR TITLE
Use official ubuntu:14.04 image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,3 @@
-.git/*
-.gitignore
-LICENSE
-README.md
-examples
-test/*
-wercker.yml
-.env
-coreos/*
-script/*
+*
+!Dockerfile
+!files/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM quay.io/wantedly/buildpack-deps:14.04
-MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
+FROM ubuntu:14.04
 
 ENV NGINX_VERSION 1.6.2
 ENV NGX_SMALL_LIGHT_VERSION 0.6.8
@@ -11,11 +10,13 @@ RUN apt-get update && \
       binutils-doc \
       bison \
       flex \
+      g++ \
       gettext \
       libpcre3 \
       libpcre3-dev \
       libssl-dev \
-      libperl-dev && \
+      libperl-dev \
+      make && \
     rm -rf /var/lib/apt/lists/*
 
 # Build ImageMagick with WebP support


### PR DESCRIPTION
## WHY
Now we're using [quay.io/wantedly/buildpack-deps](https://github.com/wantedly/buildpack-deps) as base image. However, buildpack-deps image contains some unnecessary packages (`imagemagick` is installed!). It makes nginx-image-server image fat.

## WHAT
Use official `ubuntu:14.04` image and install essential packages only.
This change reduces image size by 260MB.

```bash
$ docker images | grep nginx-image-server
quay.io/wantedly/nginx-image-server    new                 5f66f6e88ddf        10 minutes ago      654.5 MB
quay.io/wantedly/nginx-image-server    latest              72fe212000be        5 months ago        918.3 MB
```